### PR TITLE
build: add compatibility with cmake 4.0/4.1

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Install build tools
       if: ${{ matrix.CC == 'clang-19' }}
-      run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 19 && sudo apt install libc++-19-dev
+      run: sudo apt install clang-19 libc++-19-dev
 
     - name: Build project
       run: |

--- a/.github/workflows/msan.yml
+++ b/.github/workflows/msan.yml
@@ -1,0 +1,50 @@
+name: MSAN CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Install build tools
+      run: sudo apt -y install clang-19 ninja-build
+
+    - name: Checkout LLVM
+      uses: actions/checkout@v4
+      with:
+        repository: llvm/llvm-project
+        ref: release/19.x
+        path: llvm-project
+
+    - name: Build libc++ with MSAN
+      run: |
+        cd llvm-project
+        CC=clang-19 CXX=clang++-19 cmake -G Ninja -S runtimes -B build_libcxx \
+           -DCMAKE_BUILD_TYPE=Release \
+           -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
+           -DLLVM_USE_SANITIZER=Memory \
+           -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
+           -DCMAKE_INSTALL_PREFIX=/opt/llvm
+        ninja -C build_libcxx install
+
+    - name: Checkout project
+      uses: actions/checkout@v4
+
+    - name: Build project
+      run: |
+        CC=clang-19 CXX=clang++-19 cmake -G Ninja -B build \
+           -DENABLE_MEMORY_SANITIZER=1 \
+           -DMSAN_CXX_FLAGS_EXTRA="-O2;-I/opt/llvm/include/c++/v1" \
+           -DMSAN_LINK_FLAGS_EXTRA="-L/opt/llvm/lib"
+        LD_LIBRARY_PATH=/opt/llvm/lib cmake --build build --target genesis_tests
+
+    - name: Run tests
+      run: |
+        sudo sysctl vm.mmap_rnd_bits=28 # ref: https://github.com/google/sanitizers/issues/1614
+        cd build
+        LD_LIBRARY_PATH=/opt/llvm/lib ctest --output-on-failure --exclude-regex "M68K.MCL|M68K_PERFORMANCE.*"

--- a/.github/workflows/qemu-i686.yml
+++ b/.github/workflows/qemu-i686.yml
@@ -48,14 +48,13 @@ jobs:
         sudo umount genesis # umount from runner to avoid disk.raw corruption
         screen -dmS web-server python3 -m http.server 8000 --bind 127.0.0.1 # server ssh-key and modloop file
         sudo screen -dmS qemu qemu-system-i386 -accel kvm -cpu host \
-          -M microvm,x-option-roms=off,pic=off,pit=off,rtc=off \
           -m 2048 -smp 2 -nographic \
           -kernel vmlinuz-lts \
           -initrd initramfs-lts \
           -drive format=raw,file=disk.raw,if=none,id=disk0 \
-          -device virtio-blk-device,drive=disk0 \
+          -device virtio-blk-pci,drive=disk0 \
           -netdev user,id=net0,hostfwd=tcp:0.0.0.0:2222-:22 \
-          -device virtio-net-device,netdev=net0  \
+          -device virtio-net-pci,netdev=net0  \
           -append "ip=dhcp alpine_repo=https://dl-cdn.alpinelinux.org/alpine/${{matrix.ALPINE_VER}}/main \
           modloop=http://10.0.2.2:8000/modloop-lts console=ttyS0 \
           ssh_key=http://10.0.2.2:8000/ssh-key.pub"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.10)
 project (genesis)
 
 set(CMAKE_CXX_STANDARD 23)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,15 @@ endif()
 
 # Set compiler flags for MemorySanitizer if enabled
 if(ENABLE_MEMORY_SANITIZER)
-	if (MSVC)
-		message(FATAL_ERROR "MemorySanitizer is not supported on MSVC.")
+	if (MSVC OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		message(FATAL_ERROR "MemorySanitizer is not supported on MSVC and GCC.")
 	else()
-		# TODO: we need to build c++ std lib with memory sanitize flags
-		list(APPEND GENESIS_CXX_FLAGS -fsanitize=memory -fPIE -fno-omit-frame-pointer -g)
-		list(APPEND GENESIS_LINK_FLAGS -fsanitize=memory -pie)
+		# Specify path to msan-instrumented libc++ using MSAN_CXX_FLAGS_EXTRA and MSAN_LINK_FLAGS_EXTRA
+		set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+		list(APPEND MSAN_CXX_FLAGS -fsanitize=memory -fno-omit-frame-pointer -g -stdlib=libc++ ${MSAN_CXX_FLAGS_EXTRA})
+		list(APPEND MSAN_LINK_FLAGS -fsanitize=memory -stdlib=libc++ ${MSAN_LINK_FLAGS_EXTRA})
+		list(APPEND GENESIS_CXX_FLAGS ${MSAN_CXX_FLAGS})
+		list(APPEND GENESIS_LINK_FLAGS ${MSAN_LINK_FLAGS})
 	endif()
 endif()
 

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.10)
 
 project(extra_tools)
 

--- a/genesis/CMakeLists.txt
+++ b/genesis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.10)
 
 project (genesis)
 
@@ -10,7 +10,7 @@ set(SDL_TEST FALSE CACHE BOOL "Do not build the SDL test library")
 FetchContent_Declare(
 	SDL
 	GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-	GIT_TAG release-2.28.5
+	GIT_TAG release-2.32.8
 	# GIT_TAG main # use SDL3::SDL3
 	GIT_SHALLOW TRUE
 	GIT_PROGRESS TRUE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,9 @@ project(tests)
 
 include(FetchContent)
 
+add_compile_options(${MSAN_CXX_FLAGS})
+add_link_options(${MSAN_LINK_FLAGS})
+
 FetchContent_Declare(
 	googletest
 
@@ -84,7 +87,7 @@ target_link_libraries(${GENESIS_TESTS} nlohmann_json::nlohmann_json)
 target_link_libraries(${GENESIS_TESTS} ${GENESIS_LIB})
 
 include(GoogleTest)
-gtest_discover_tests(${GENESIS_TESTS})
+gtest_discover_tests(${GENESIS_TESTS} PROPERTIES DISCOVERY_TIMEOUT 60)
 
 # copy z80 exercisers
 file(COPY z80/exercisers/Spectrum/zexdoc DESTINATION z80)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.10)
 project(tests)
 
 include(FetchContent)
@@ -7,7 +7,7 @@ FetchContent_Declare(
 	googletest
 
 	GIT_REPOSITORY https://github.com/google/googletest.git
-	GIT_TAG release-1.12.0
+	GIT_TAG v1.17.0
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
@@ -16,7 +16,7 @@ FetchContent_Declare(
 	json
 
 	GIT_REPOSITORY https://github.com/nlohmann/json.git
-	GIT_TAG v3.11.2
+	GIT_TAG v3.12.0
 )
 
 FetchContent_MakeAvailable(googletest json)


### PR DESCRIPTION
cmake 4.1 requires declaring minimum required version = 3.10 so update cmake_minimum_required and update dependencies to support cmake 4.1